### PR TITLE
Fix static files directory and React imports

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ dotenv.config();
 
 // https://stackoverflow.com/questions/8817423/why-is-dirname-not-defined-in-node-repl
 const __dirname = path.resolve();
-app.use(express.static(path.join(__dirname, "build")));
+app.use(express.static(path.join(__dirname, "public")));
 
 const moesifManagementToken = process.env.MOESIF_MANAGEMENT_TOKEN;
 const templateWorkspaceId = process.env.MOESIF_TEMPLATE_WORKSPACE_ID;
@@ -111,7 +111,7 @@ app.get("/embed-dash(/:userId)", function (req, res) {
 });
 
 app.get("/", function (req, res) {
-  res.sendFile(path.join(__dirname, "build", "index.html"));
+  res.sendFile(path.join(__dirname, "public", "index.html"));
 });
 
 app.listen(process.env.PORT || 3050);

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import React from "react";
 // import logo from "./logo.svg";
 import "./App.css";
-import EmbeddedDash from "./EmbeddedDash";
+import EmbeddedDash from "./EmbeddedDash.js";
 
 function App() {
   return (

--- a/src/EmbeddedDash.js
+++ b/src/EmbeddedDash.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import "react-datetime/css/react-datetime.css";
 import Datetime from "react-datetime";
-import EmbeddedDisplay from "./EmbeddedDisplay";
+import EmbeddedDisplay from "./EmbeddedDisplay.js";
 
 function EmbeddedDash() {
   const [dashEmbedInfo, setEmbedInfo] = useState(null);

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import App from './App.js';
+import * as serviceWorker from './serviceWorker.js';
 
 ReactDOM.render(
   <React.StrictMode>


### PR DESCRIPTION
Fixes the following issues:
- The static files directory we serve is `public` not `build`.
- React imports when using ESM need to have explicit file extensions specified for them to work.